### PR TITLE
fix: env variable typeo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ pip install .
 The application uses `python-dotenv` to manage database credentials. Create a `.env` file in your working directory with the following variables:
 
 ```env
-DB_HOST=localhost
-DB_USER=your_user
-DB_PASSWORD=your_password
-DB_DATABASE=your_database_name
-DB_PORT=3306
+MYSQL_CSV_LOAD_HOST=localhost
+MYSQL_CSV_LOAD_USER=your_user
+MYSQL_CSV_LOAD_PASSWORD=your_password
+MYSQL_CSV_LOAD_DATABASE=your_database_name
 
 ```
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -30,11 +30,10 @@ pip install .
 A aplicação utiliza o `python-dotenv` para gerenciar as credenciais do banco de dados. Crie um arquivo `.env` no seu diretório de trabalho com as seguintes variáveis:
 
 ```env
-DB_HOST=localhost
-DB_USER=seu_usuario
-DB_PASSWORD=sua_senha
-DB_DATABASE=nome_do_seu_banco
-DB_PORT=3306
+MYSQL_CSV_LOAD_HOST=localhost
+MYSQL_CSV_LOAD_USER=seu_usuario
+MYSQL_CSV_LOAD_PASSWORD=sua_senha
+MYSQL_CSV_LOAD_DATABASE=nome_do_seu_banco
 
 ```
 


### PR DESCRIPTION
This pull request updates the environment variable names in both the English and Portuguese README files (README.md and README.pt-BR.md) to use the MYSQL_CSV_LOAD_ prefix instead of the generic DB_ prefix, and removes the port variable. There are no review comments, so I have no feedback to provide.