### PR TITLE
feat: Adiciona configuração de porta do banco de dados

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ MYSQL_CSV_LOAD_HOST=localhost
 MYSQL_CSV_LOAD_USER=your_user
 MYSQL_CSV_LOAD_PASSWORD=your_password
 MYSQL_CSV_LOAD_DATABASE=your_database_name
-
+MYSQL_CSV_LOAD_PORT=your_database_port      # 3306 when empty or not set
 ```
 
 ---

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -34,7 +34,7 @@ MYSQL_CSV_LOAD_HOST=localhost
 MYSQL_CSV_LOAD_USER=seu_usuario
 MYSQL_CSV_LOAD_PASSWORD=sua_senha
 MYSQL_CSV_LOAD_DATABASE=nome_do_seu_banco
-
+MYSQL_CSV_LOAD_PORT=porta_do_seu_banco      # se em branco ou não configurado usa 3306
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mysql-csv-load"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python script to load data from a CSV file into a MySQL database table."
 dependencies = [
 "mysql-connector-python==9.3.0",

--- a/src/mysql_csv_load/main.py
+++ b/src/mysql_csv_load/main.py
@@ -30,7 +30,8 @@ def run():
     db_user = os.getenv("MYSQL_CSV_LOAD_USER")
     db_password = os.getenv("MYSQL_CSV_LOAD_PASSWORD")
     db_name = os.getenv("MYSQL_CSV_LOAD_DATABASE")
-    db_port = os.getenv("MYSQL_CSV_LOAD_PORT", 3306)
+    db_port_env = os.getenv("MYSQL_CSV_LOAD_PORT")
+    db_port = int(db_port_env) if db_port_env and db_port_env.strip().isdigit() else 3306
 
     if not db_host or not db_user or not db_name:
         print("Erro: As variáveis de ambiente MYSQL_CSV_LOAD_HOST, MYSQL_CSV_LOAD_USER e MYSQL_CSV_LOAD_DATABASE devem ser configuradas.")

--- a/src/mysql_csv_load/main.py
+++ b/src/mysql_csv_load/main.py
@@ -30,6 +30,7 @@ def run():
     db_user = os.getenv("MYSQL_CSV_LOAD_USER")
     db_password = os.getenv("MYSQL_CSV_LOAD_PASSWORD")
     db_name = os.getenv("MYSQL_CSV_LOAD_DATABASE")
+    db_port = os.getenv("MYSQL_CSV_LOAD_PORT", 3306)
 
     if not db_host or not db_user or not db_name:
         print("Erro: As variáveis de ambiente MYSQL_CSV_LOAD_HOST, MYSQL_CSV_LOAD_USER e MYSQL_CSV_LOAD_DATABASE devem ser configuradas.")
@@ -40,7 +41,8 @@ def run():
             host=db_host,
             user=db_user,
             password=db_password,
-            database=db_name
+            database=db_name,
+            port=db_port
         )
         cursor = conn.cursor()
     except mysql.connector.Error as err:


### PR DESCRIPTION
Adiciona a variável de ambiente  para permitir a configuração da porta de conexão com o banco de dados MySQL.

- O script agora utiliza a porta especificada ou a padrão (3306).
- A documentação (README.md e README.pt-BR.md) foi atualizada.
- A versão do projeto foi atualizada para 0.2.0.